### PR TITLE
Fix presenting PKAddPassesViewController from a modal

### DIFF
--- a/ios/RNPassKit/RNPassKit.m
+++ b/ios/RNPassKit/RNPassKit.m
@@ -31,11 +31,8 @@ RCT_EXPORT_METHOD(addPass:(NSString *)base64Encoded
   }
   
   dispatch_async(dispatch_get_main_queue(), ^{
-    UIApplication *sharedApplication = RCTSharedApplication();
-    UIWindow *window = sharedApplication.keyWindow;
-    if (window) {
-      UIViewController *rootViewController = window.rootViewController;
-      if (rootViewController) {
+    UIViewController *rootViewController = [self getPresenterViewController];
+    if (rootViewController) {
         PKAddPassesViewController *addPassesViewController = [[PKAddPassesViewController alloc] initWithPass:pass];
         addPassesViewController.delegate = self;
         [rootViewController presentViewController:addPassesViewController animated:YES completion:^{
@@ -43,7 +40,6 @@ RCT_EXPORT_METHOD(addPass:(NSString *)base64Encoded
           resolve(nil);
         }];
         return;
-      }
     }
     
     reject(@"", @"Failed to present PKAddPassesViewController.", nil);
@@ -82,4 +78,15 @@ RCT_EXPORT_METHOD(addPass:(NSString *)base64Encoded
   return @[@"addPassesViewControllerDidFinish"];
 }
 
+#pragma mark - helper methods
+​
+-(UIViewController*)getPresenterViewController {
+    UIApplication *sharedApplication = RCTSharedApplication();
+    UIViewController *presentingViewcontroller = sharedApplication.delegate.window.rootViewController;
+    if(presentingViewcontroller.presentedViewController != nil) {
+        presentingViewcontroller = presentingViewcontroller.presentedViewController;
+    }
+    return presentingViewcontroller;
+}
+​
 @end


### PR DESCRIPTION
Fixes error when trying to present the PKAddPassesViewController from an already open modal. 

Example of the error
`Warning: Attempt to present <PKAddPassesViewController: 0x7fab12525390> on <RNNBottomTabsController: 0x7fab220b8000> whose view is not in the window hierarchy!`