### PR TITLE
feat(ios only): added function to retrieve pass url from pass with specified passTypeIdentifier and SerialNumber

### DIFF
--- a/PassKit.ios.js
+++ b/PassKit.ios.js
@@ -16,6 +16,10 @@ export default {
     return nativeModule.addPass(base64Encoded)
   },
 
+  getUrlFromPass: (passTypeIdentifier: string, serialNumber: string): Promise<string>  => {
+    return nativeModule.getUrlFromPass(passTypeIdentifier, serialNumber)
+  },
+
   presentAddPassesViewController: (base64Encoded: string): Promise<void> => {
     // eslint-disable-next-line no-console
     console.warn(

--- a/ios/RNPassKit/RNPassKit.m
+++ b/ios/RNPassKit/RNPassKit.m
@@ -46,6 +46,19 @@ RCT_EXPORT_METHOD(addPass:(NSString *)base64Encoded
   });
 }
 
+RCT_EXPORT_METHOD(getUrlFromPass:(NSString *)withPassTypeIdentifier
+                  serialNumber:(NSString *)serialNumber
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejector:(RCTPromiseRejectBlock)reject) {
+  PKPassLibrary *passLibrary = [[PKPassLibrary alloc] init];
+  PKPass *pass = [passLibrary passWithPassTypeIdentifier:withPassTypeIdentifier serialNumber:serialNumber];
+  if (pass) {
+    resolve(pass.passURL.absoluteString);
+  } else {
+    reject(@"", @"Pass not found.\nMake sure your app has the Wallet capability.", nil);
+  }
+}
+
 RCT_EXPORT_METHOD(containsPass:(NSString *)base64Encoded
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejector:(RCTPromiseRejectBlock)reject) {


### PR DESCRIPTION
Example of what a pass url looks like:
![shoebox example](https://user-images.githubusercontent.com/59275080/188737979-c8aba93c-487a-44b5-889d-3142652d8df2.png)

Note: In order to use this in your app, you will need to give your app **Wallet Permissions** which you can do through XCode:
![passkit_pr](https://user-images.githubusercontent.com/59275080/188738074-9e74c70c-ecd9-433d-9476-ba9615cc460a.png)
